### PR TITLE
Fix `run` not waiting for result as as_completed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.2 (unreleased)
+
+- Fix `run` method not failing fast
+
 ## 0.1.1
 
 - Added support for Python 3.5

--- a/examples/backpressure.py
+++ b/examples/backpressure.py
@@ -1,3 +1,9 @@
+"""
+An example of how futureproof handles backpressure of tasks
+versus concurrent.futures which can hog resources and even cause the
+system to be unresponsive in extreme cases.
+"""
+
 import concurrent.futures
 import sys
 import logging
@@ -23,7 +29,11 @@ def custom_sum(a, b):
 
 
 def with_futureproof():
-    logger.info("Starting backpressure test")
+    logger.info("Starting backpressure test with 1,000,000 tasks")
+    logger.info(
+        "You may KeyboardInterrupt at any point "
+        "and the executor will stop almost immediately"
+    )
     ex = futureproof.FutureProofExecutor(max_workers=2)
     with futureproof.TaskManager(
         ex, error_policy=futureproof.ErrorPolicyEnum.RAISE
@@ -35,16 +45,16 @@ def with_futureproof():
 
 
 def with_futures():
-    logger.info("Starting backpressure test")
     response = input(
-        "This example will take a fair bit of memory and might "
-        "block and not respond to KeyboardInterrupts, a SIGINT will "
+        "Leaving this example running too will take a fair bit of memory and "
+        "might block and not respond to KeyboardInterrupts, a SIGINT will "
         "be required to stop it, are you sure you want to continue? [Y/n] "
     )
     if response == "n":
         print("Aborting as requested")
         return
 
+    logger.info("Starting backpressure test with 1,000,000 tasks")
     with concurrent.futures.ThreadPoolExecutor(max_workers=2) as ex:
         fn = partial(custom_sum, b=1)
         ex.map(fn, range(1_000_000_000))

--- a/examples/fail_fast.py
+++ b/examples/fail_fast.py
@@ -34,7 +34,7 @@ def with_futureproof():
     logger.info("Starting test")
     ex = futureproof.FutureProofExecutor(max_workers=2)
     with futureproof.TaskManager(
-        ex, error_policy=futureproof.ErrorPolicyEnum.RAISE
+        ex, error_policy=futureproof.ErrorPolicyEnum.RAISE  # RAISE is the default
     ) as tm:
         for i in range(50):
             tm.submit(flaky_sum, i, 1)

--- a/examples/monitoring.py
+++ b/examples/monitoring.py
@@ -1,0 +1,52 @@
+"""
+An example of how futureproof monitors the tasks and prints progress
+versus concurrent.futures which shows no information.
+"""
+
+import concurrent.futures
+import sys
+import logging
+import threading
+import time
+from functools import partial
+from random import random
+
+import futureproof
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="[%(asctime)s %(thread)s] %(message)s",
+    datefmt="%H:%M:%S",
+)
+
+logger = logging.getLogger("futureproof")
+
+
+def delayed_sum(a, b):
+    time.sleep(random() + 5)
+    return a + b
+
+
+def with_futureproof():
+    logger.info("Starting test")
+    ex = futureproof.FutureProofExecutor(max_workers=2)
+    with futureproof.TaskManager(ex) as tm:
+        for i in range(50):
+            tm.submit(delayed_sum, i, 1)
+        for task in tm.as_completed():
+            print(task.result)
+
+
+def with_futures():
+    logger.info("Starting test")
+    logger.info("The results come slowly without indication that things are working")
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as ex:
+        fs = [ex.submit(delayed_sum, i, 1) for i in range(50)]
+        for future in concurrent.futures.as_completed(fs):
+            print(future.result(), flush=True)
+
+
+if len(sys.argv) > 1 and sys.argv[1] == "futures":
+    with_futures()
+else:
+    with_futureproof()

--- a/src/futureproof/__init__.py
+++ b/src/futureproof/__init__.py
@@ -1,7 +1,7 @@
 from .task_manager import TaskManager, ErrorPolicyEnum
 from .executors import FutureProofExecutor
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 
 __title__ = "futureproof"
 __description__ = "Bulletproof concurrent.futures"

--- a/tests/test_futureproof.py
+++ b/tests/test_futureproof.py
@@ -25,7 +25,9 @@ def custom_sum(a, b):
     return a + b
 
 
-def flaky_sum(a, b):
+def flaky_sum(a, b, delay=0):
+    if delay:
+        time.sleep(delay)
     if a % 5 == 0:
         raise ValueError
     return a + b
@@ -90,7 +92,7 @@ def test_submit_flaky_functions(executor):
     tm = futureproof.TaskManager(executor)
 
     for i in range(1, 101):
-        tm.submit(flaky_sum, i, 1)
+        tm.submit(flaky_sum, i, 1, delay=0.1)
 
     with pytest.raises(ValueError):
         tm.run()


### PR DESCRIPTION
`run` now consumes `as_completed`